### PR TITLE
constructor -> ctor

### DIFF
--- a/packages/es-scraper/scripts/intrinsics.ts
+++ b/packages/es-scraper/scripts/intrinsics.ts
@@ -190,7 +190,7 @@ function makeClass(s: Section): JSClass {
   const prototypeProperties = makeProperties(protoPropSecs, false);
   const instanceMethods = makeProperties(protoPropSecs, true);
   const instanceProperties = instancePropSecs.map(makeProperty);
-  const classConstructor = makeConstructor(ctorSection);
+  const ctor = makeConstructor(ctorSection);
   // TODO: https://github.com/tc39/ecma262/pull/3054
   const funcLengthProp = staticProperties.findIndex((p) =>
     p.name.endsWith("Function.length"),
@@ -205,7 +205,7 @@ function makeClass(s: Section): JSClass {
       .map((_, el) => $(el).text())
       .get();
     assert(para.length === 1);
-    classConstructor!.length = Number(
+    ctor!.length = Number(
       para[0]!.match(/with a value of (?<length>\d+)/u)!.groups!.length!,
     );
   }
@@ -231,7 +231,7 @@ function makeClass(s: Section): JSClass {
     id: s.id,
     global: false,
     extends: getExtends(),
-    classConstructor,
+    ctor,
     staticProperties,
     staticMethods,
     prototypeProperties,

--- a/packages/es-scraper/scripts/intrinsics.ts
+++ b/packages/es-scraper/scripts/intrinsics.ts
@@ -190,7 +190,7 @@ function makeClass(s: Section): JSClass {
   const prototypeProperties = makeProperties(protoPropSecs, false);
   const instanceMethods = makeProperties(protoPropSecs, true);
   const instanceProperties = instancePropSecs.map(makeProperty);
-  const constructor = makeConstructor(ctorSection);
+  const classConstructor = makeConstructor(ctorSection);
   // TODO: https://github.com/tc39/ecma262/pull/3054
   const funcLengthProp = staticProperties.findIndex((p) =>
     p.name.endsWith("Function.length"),
@@ -205,7 +205,7 @@ function makeClass(s: Section): JSClass {
       .map((_, el) => $(el).text())
       .get();
     assert(para.length === 1);
-    constructor!.length = Number(
+    classConstructor!.length = Number(
       para[0]!.match(/with a value of (?<length>\d+)/u)!.groups!.length!,
     );
   }
@@ -231,7 +231,7 @@ function makeClass(s: Section): JSClass {
     id: s.id,
     global: false,
     extends: getExtends(),
-    constructor,
+    classConstructor,
     staticProperties,
     staticMethods,
     prototypeProperties,

--- a/packages/es-scraper/src/types.ts
+++ b/packages/es-scraper/src/types.ts
@@ -49,7 +49,7 @@ export type JSClass = {
   id: string;
   global: boolean;
   extends: string | undefined;
-  constructor: JSConstructor | null;
+  classConstructor: JSConstructor | null;
   staticProperties: JSProperty[];
   staticMethods: JSMethod[];
   prototypeProperties: JSProperty[];

--- a/packages/es-scraper/src/types.ts
+++ b/packages/es-scraper/src/types.ts
@@ -49,7 +49,7 @@ export type JSClass = {
   id: string;
   global: boolean;
   extends: string | undefined;
-  classConstructor: JSConstructor | null;
+  ctor: JSConstructor | null;
   staticProperties: JSProperty[];
   staticMethods: JSMethod[];
   prototypeProperties: JSProperty[];


### PR DESCRIPTION
This renames the `constructor` parameter of the JavaScript class object to `classConstructor`.  Since `constructor` is a property on object prototypes, we can't simply check if `{class}.constructor` exists or is non-null.
